### PR TITLE
chore: bump version to 2.3.7 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the Die Hard module will be documented in this file.
 
+## [2.3.7] - 2025-10-06
+
+### Fixed
+- **Karma No Longer Applies to Damage Rolls** - Karma bonuses now correctly excluded from damage rolls
+- Added `isDamageRoll()` helper function to detect damage rolls by:
+  - Roll constructor name (`DamageRoll`)
+  - Message flavor containing "damage"
+  - Roll options type or flavor containing "damage"
+- Modified karma processing to skip damage rolls
+- Updated roll history tracking to exclude damage rolls
+
+### Technical
+- Karma now only applies to d20-based rolls (ability checks, attack rolls, saving throws)
+- Roll history for karma calculations excludes damage rolls
+- Enhanced roll type detection for proper karma application
+
 ## [2.3.6] - 2025-10-05
 
 ### Fixed

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "foundry-die-hard",
   "title": "Die Hard",
   "description": "A module to influence and manipulate die rolls in Foundry VTT. Allows GMs to fudge rolls and implement karma systems with per-user controls.",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "compatibility": {
     "minimum": "13",
     "verified": "13"


### PR DESCRIPTION
Fixes #1

## Summary
Updated module version and changelog to document the karma/damage roll fix.

## Changes
- Bumped version from 2.3.6 to 2.3.7 in module.json
- Added changelog entry for v2.3.7 documenting:
  - Karma exclusion from damage rolls
  - isDamageRoll() helper function implementation
  - Roll type detection logic
  - Updated roll history tracking

Generated with [Claude Code](https://claude.ai/code)