### PR TITLE
chore: bump version to 2.3.9 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the Die Hard module will be documented in this file.
 
+## [2.3.9] - 2025-10-06
+
+### Fixed
+- **Karma Modifier Application Order** - Karma adjustments now apply to the raw d20 roll before any other modifiers
+- Previously karma was added as a modifier term at the end of the roll formula (after ability scores, proficiency, etc.)
+- Now karma directly modifies the d20 dice result value itself, ensuring proper application order
+- This ensures karma affects the base roll value before ability modifiers, proficiency bonuses, and other adjustments are calculated
+
+### Technical
+- Updated `adjustRollToMinimum()` to modify the d20 DiceTerm result directly instead of adding modifier terms
+- Updated `adjustRollByAmount()` to modify the d20 DiceTerm result directly instead of adding modifier terms
+- Both functions now find the d20 DiceTerm in the roll and modify its `result` property
+- Ensures karma adjustments happen to the raw dice value before any other modifiers are applied
+
 ## [2.3.8] - 2025-10-06
 
 ### Fixed

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "foundry-die-hard",
   "title": "Die Hard",
   "description": "A module to influence and manipulate die rolls in Foundry VTT. Allows GMs to fudge rolls and implement karma systems with per-user controls.",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "compatibility": {
     "minimum": "13",
     "verified": "13"


### PR DESCRIPTION
Updated version number and changelog to document the karma modifier fix from issue #5.

## Changes
- Bumped version from 2.3.8 to 2.3.9 in module.json
- Added changelog entry for v2.3.9 documenting karma application order fix
- Karma now applies to raw d20 before other modifiers (ability scores, proficiency, etc.)

Resolves #5

Generated with [Claude Code](https://claude.ai/code)