### PR TITLE
Fix die karma adjustment for Recall Knowledge macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the Die Hard module will be documented in this file.
 
+## [2.3.13] - 2025-10-06
+
+### Fixed
+- **Improved d20 Detection for Karma Adjustments** - Enhanced die detection logic to better handle PF2e Recall Knowledge macros and other special rolls
+- Added multiple fallback approaches for finding d20 dice in rolls:
+  - First tries direct roll terms
+  - Falls back to nested dice array
+  - Finally tries any DiceTerm as last resort
+- Enhanced logging to diagnose roll structure issues when karma fails to apply
+- Better error messages showing roll structure when d20 cannot be found
+
+### Technical
+- Updated `adjustRollToMinimum()` with three-tier d20 detection approach
+- Updated `adjustRollByAmount()` with three-tier d20 detection approach
+- Added detailed logging of roll structure (constructor name, formula, terms)
+- Added JSON serialization of roll structure in error cases for debugging
+- Enhanced `preCreateChatMessage` hook with more comprehensive logging
+
 ## [2.3.12] - 2025-10-06
 
 ### Fixed

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "foundry-die-hard",
   "title": "Die Hard",
   "description": "A module to influence and manipulate die rolls in Foundry VTT. Allows GMs to fudge rolls and implement karma systems with per-user controls.",
-  "version": "2.3.12",
+  "version": "2.3.13",
   "compatibility": {
     "minimum": "13",
     "verified": "13"


### PR DESCRIPTION
Enhanced d20 detection logic to handle PF2e Recall Knowledge macros and other special rolls.

Added three-tier fallback approach for finding d20 dice in rolls, plus comprehensive logging for debugging.

Fixes #14

Generated with [Claude Code](https://claude.ai/code)