### PR TITLE
Fix cumulative karma adjustment reset issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the Die Hard module will be documented in this file.
 
+## [2.3.14] - 2025-10-06
+
+### Fixed
+- **CRITICAL: Cumulative Karma Adjustment Reset** - Fixed cumulative adjustment counter not being reset when average reaches threshold
+- Previously, cumulative adjustments would continue to escalate even after the average was corrected
+- Now properly resets cumulative counter when the new average (after adjustment) meets or exceeds the threshold
+- Also resets when average is already at or above threshold before applying any adjustment
+- Fixed in both v13 implementation (dice-manipulator.js) and legacy v10 code (DieHardSystem.js)
+
+### Added
+- **Cumulative State Management** - Added proper tracking of cumulative adjustment counts per user
+- New setting `karmaCumulativeState` stores cumulative counts globally
+- Added methods in config.js: `getCumulativeCount()`, `setCumulativeCount()`, `resetCumulativeCount()`
+- Cumulative state now persists across sessions and is properly managed
+
+### Technical
+- Updated `processAverageKarma()` in dice-manipulator.js to be async and track cumulative state
+- Added logic to calculate new average after adjustment and reset counter when threshold is reached
+- Updated `processKarma()` to be async and await the average karma processing
+- Updated preCreateChatMessage hook to await karma processing
+- Fixed DieHardSystem.js roll evaluation to check if adjusted average reaches threshold
+- Cumulative counter now properly resets in three scenarios:
+  1. When average is already >= threshold (no adjustment needed)
+  2. When adjusted roll brings average >= threshold (adjustment worked)
+  3. When cumulative mode is disabled (always resets to 1)
+
 ## [2.3.13] - 2025-10-06
 
 ### Fixed

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "foundry-die-hard",
   "title": "Die Hard",
   "description": "A module to influence and manipulate die rolls in Foundry VTT. Allows GMs to fudge rolls and implement karma systems with per-user controls.",
-  "version": "2.3.13",
+  "version": "2.3.14",
   "compatibility": {
     "minimum": "13",
     "verified": "13"

--- a/scripts/classes/DieHardSystem.js
+++ b/scripts/classes/DieHardSystem.js
@@ -317,10 +317,18 @@ export default class DieHardSystem {
             }
             dieHardLog(false, functionLogName + ' - Avg Karma adjustment - new result', roll.result);
 
-            avgKarmaData.history.push(roll.result)
-            while (avgKarmaData.history.length > avgKarmaData.history.history) {
-              avgKarmaData.history.shift()
+            // Check if the new average (after adjustment) reaches the threshold
+            // Create a copy of history with the adjusted roll to check new average
+            const historyWithAdjusted = [...avgKarmaData.history.slice(1), roll.result];
+            const newAverage = historyWithAdjusted.reduce((a, b) => a + b, 0) / historyWithAdjusted.length;
+
+            dieHardLog(false, functionLogName + ' - Avg Karma new average after adjustment', newAverage);
+
+            if (newAverage >= avgKarmaSettings.threshold) {
+              dieHardLog(false, functionLogName + ' - Avg Karma threshold reached, resetting cumulative');
+              avgKarmaData.cumulative = 0;
             }
+
             DieHard.dmToGm('DieHard-Karma: Avg Karma for ' + game.users.current.name + ' adjusted a roll of ' + originalResult + ' to a ' + roll.result);
           } else {
             dieHardLog(false, functionLogName + ' - Avg Karma adjustment not needed', avgKarmaData.history.length, avgKarmaSettings.history, avgKarmaSettings.threshold);

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -193,7 +193,45 @@ export class DieHardConfig {
     delete history[userId];
     await this.setRollHistory(history);
   }
-  
+
+  /**
+   * Get karma cumulative state
+   */
+  getKarmaCumulativeState() {
+    return game.settings.get(MODULE_ID, 'karmaCumulativeState') || {};
+  }
+
+  /**
+   * Set karma cumulative state
+   */
+  async setKarmaCumulativeState(state) {
+    return await game.settings.set(MODULE_ID, 'karmaCumulativeState', state);
+  }
+
+  /**
+   * Get cumulative adjustment count for a user
+   */
+  getCumulativeCount(userId) {
+    const state = this.getKarmaCumulativeState();
+    return state[userId] || 0;
+  }
+
+  /**
+   * Set cumulative adjustment count for a user
+   */
+  async setCumulativeCount(userId, count) {
+    const state = this.getKarmaCumulativeState();
+    state[userId] = count;
+    await this.setKarmaCumulativeState(state);
+  }
+
+  /**
+   * Reset cumulative adjustment count for a user
+   */
+  async resetCumulativeCount(userId) {
+    await this.setCumulativeCount(userId, 0);
+  }
+
   /**
    * Parse fudge formula
    */

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -156,6 +156,14 @@ function registerSettings() {
     type: Object,
     default: {}
   });
+
+  // Karma cumulative state (tracks cumulative adjustment count per user)
+  game.settings.register(MODULE_ID, 'karmaCumulativeState', {
+    scope: 'world',
+    config: false,
+    type: Object,
+    default: {}
+  });
 }
 
 /**
@@ -284,7 +292,7 @@ function setupDiceRollHooks() {
       }
 
       if (karmaEnabled) {
-        manipulator.processKarma(roll, userId);
+        await manipulator.processKarma(roll, userId);
       }
 
       // Check if the roll was modified


### PR DESCRIPTION
## Summary

Fixed cumulative karma adjustment counter not being reset when average reaches threshold.

## Changes

- Added cumulative state management to config.js
- Updated dice-manipulator.js to track and reset cumulative state
- Fixed DieHardSystem.js (legacy v10 code) to check adjusted average
- Made karma processing async for proper state updates
- Updated CHANGELOG.md and bumped version to 2.3.14

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)