### PR TITLE
Fix roll adjustments not being applied to chat cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the Die Hard module will be documented in this file.
 
+## [2.3.15] - 2025-10-06
+
+### Fixed
+- **CRITICAL: Roll adjustments not applied to chat cards** - Fixed issue where roll modifications were not being displayed in chat
+- Roll objects were being modified in memory but not properly serialized for Foundry v13
+- Now properly converts rolls to JSON before updating message source data
+- Fixes issue introduced in 2.3.14 where chat cards displayed but rolls weren't adjusted
+
+### Technical
+- Updated `preCreateChatMessage` hook to serialize modified rolls using `toJSON()` before updating message source
+- Ensures modified roll data is properly persisted in Foundry v13's data structure
+- Added logging of serialized roll totals for debugging
+
 ## [2.3.14] - 2025-10-06
 
 ### Fixed

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "foundry-die-hard",
   "title": "Die Hard",
   "description": "A module to influence and manipulate die rolls in Foundry VTT. Allows GMs to fudge rolls and implement karma systems with per-user controls.",
-  "version": "2.3.14",
+  "version": "2.3.15",
   "compatibility": {
     "minimum": "13",
     "verified": "13"

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -305,12 +305,17 @@ function setupDiceRollHooks() {
     }
 
     // If rolls were modified, update the message with modified rolls
+    // In Foundry v13, we need to convert rolls to JSON for proper serialization
     if (modified) {
+      // Convert rolls to JSON to ensure they're properly serialized
+      const serializedRolls = message.rolls.map(r => r.toJSON());
+
       message.updateSource({
-        rolls: message.rolls
+        rolls: serializedRolls
       });
 
       log('Rolls modified and applied to message');
+      log('Serialized rolls:', serializedRolls.map(r => r._total));
     }
 
     log('=== End Processing ===');


### PR DESCRIPTION
## Summary
- Fixed critical issue where roll modifications weren't displayed in chat
- Roll objects were being modified but not properly serialized for Foundry v13
- Now converts rolls to JSON using toJSON() before updating message source
- Updated version to 2.3.15
- Updated CHANGELOG.md

Fixes #18

Generated with [Claude Code](https://claude.ai/code)