### PR TITLE
Fix karma adjustments not displaying in chat messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the Die Hard module will be documented in this file.
 
+## [2.3.16] - 2025-10-06
+
+### Fixed
+- **CRITICAL: Karma adjustments not displaying in chat** - Fixed issue where karma modifications were applied but not visible in chat messages
+- Roll objects were being modified correctly but the chat message content was not being regenerated
+- Now properly clears message content to force Foundry to regenerate HTML with modified roll values
+- Fixes issue #20 where GM whispers showed adjustments but chat cards displayed original values
+
+### Technical
+- Updated `preCreateChatMessage` hook to clear content when rolls are modified
+- Added `content: ''` to `updateSource()` call to force Foundry v13 to regenerate chat HTML
+- Properly reconstructs Roll objects from modified data using `Roll.fromData()`
+- Updated misleading comment in `createChatMessage` hook
+
 ## [2.3.15] - 2025-10-06
 
 ### Fixed

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "foundry-die-hard",
   "title": "Die Hard",
   "description": "A module to influence and manipulate die rolls in Foundry VTT. Allows GMs to fudge rolls and implement karma systems with per-user controls.",
-  "version": "2.3.15",
+  "version": "2.3.16",
   "compatibility": {
     "minimum": "13",
     "verified": "13"


### PR DESCRIPTION
## Summary
- Fixed issue where karma adjustments were applied but not visible in chat messages
- Roll objects were being modified correctly but chat HTML was not regenerated
- Now forces Foundry to regenerate content by clearing it in updateSource()

## Changes
- Updated preCreateChatMessage hook to clear message content when rolls modified
- Properly reconstruct Roll objects using Roll.fromData()
- Updated misleading comment in createChatMessage hook
- Bumped version to 2.3.16

Fixes #20

Generated with [Claude Code](https://claude.ai/code)